### PR TITLE
Fix self-damage recursion

### DIFF
--- a/Xplat/src/main/java/io/github/lounode/extrabotany/common/item/equipment/shield/ElementiumShieldItem.java
+++ b/Xplat/src/main/java/io/github/lounode/extrabotany/common/item/equipment/shield/ElementiumShieldItem.java
@@ -41,9 +41,9 @@ public class ElementiumShieldItem extends ManasteelShieldItem {
 	public void onShieldBlock(ItemStack stack, LivingEntity blocker, DamageSource source, float damage) {
 		super.onShieldBlock(stack, blocker, source, damage);
 		Entity entity = source.getEntity();
-		if (entity != null && !entity.fireImmune()) {
-			entity.setSecondsOnFire(5);
-		}
+		if (entity != null) if (!entity.fireImmune() && entity != blocker) {
+            entity.setSecondsOnFire(5);
+        }
 	}
 
 	@Override

--- a/Xplat/src/main/java/io/github/lounode/extrabotany/common/item/equipment/shield/TerrasteelShieldItem.java
+++ b/Xplat/src/main/java/io/github/lounode/extrabotany/common/item/equipment/shield/TerrasteelShieldItem.java
@@ -27,7 +27,7 @@ public class TerrasteelShieldItem extends ManasteelShieldItem {
 	public void onShieldBlock(ItemStack stack, LivingEntity blocker, DamageSource source, float damage) {
 		super.onShieldBlock(stack, blocker, source, damage);
 		Entity entity = source.getEntity();
-		if (entity != null) {
+		if (entity != null) if (entity != blocker) {
 			entity.hurt(damageSource(blocker), damage * THORNS_RETURN_RATE);
 		}
 


### PR DESCRIPTION
Terrasteel Shield has the ability to return damage,
in combination with other mods, where you can *damage yourself* somehow (i.e. explosion attributed to yourself),
unchecked, **puts the Terrasteel Shild thorns into infinite recursion**, so an identity check is needed to prevent that.

(not quite clear how players have achieved that, something about mines and executed with two players).

P.S., please fix rotten maven.lounode.top dependency links, thanks.