### PR TITLE
将mythicbotany（神话植物学）加入盖亚3的兼容列表中

### DIFF
--- a/Fabric/src/main/java/io/github/lounode/extrabotany/fabric/FabricExtraBotanyConfig.java
+++ b/Fabric/src/main/java/io/github/lounode/extrabotany/fabric/FabricExtraBotanyConfig.java
@@ -166,7 +166,7 @@ public class FabricExtraBotanyConfig {
 							Set true to disable Gaia's disarm
 							""")
 					.finishValue(disableGaiaDisArm::mirror)
-					.beginValue("gaiaSpawnUnCheckList", ConfigTypes.makeList(STRING), List.of("minecraft", "botania", "extrabotany"))
+					.beginValue("gaiaSpawnUnCheckList", ConfigTypes.makeList(STRING), List.of("minecraft", "botania", "extrabotany", "mythicbotany")))
 					.withComment("""
 							盖亚三生成时不检查的ModID或者物品
 							示例：minecraft, sophisticatedbackpacks:backpack

--- a/Forge/src/main/java/io/github/lounode/extrabotany/forge/ForgeExtrabotanyConfig.java
+++ b/Forge/src/main/java/io/github/lounode/extrabotany/forge/ForgeExtrabotanyConfig.java
@@ -150,7 +150,7 @@ public class ForgeExtrabotanyConfig {
 							示例：minecraft, sophisticatedbackpacks:backpack
 							Items or ModIDs that gaia ignore to check when spawn
 							e.g. minecraft, sophisticatedbackpacks:backpack""")
-					.defineList("gaiaSpawnUnCheckList", List.of("minecraft", "botania", "extrabotany"), o -> o instanceof String);
+					.defineList("gaiaSpawnUnCheckList", List.of("minecraft", "botania", "extrabotany", "mythicbotany"), o -> o instanceof String);
 			builder.pop();//End gaia
 
 			builder.push("fakePlayer");


### PR DESCRIPTION
mythicbotany 也是 Botania 附属扩展之一，可以考虑将其加入兼容名单中？

相关 issue： https://github.com/Lounode/Extrabotany/issues/28

下游 issue： https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1462